### PR TITLE
Show important software limitation for keycode address space.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # TMK-Core ErgoDox Firmware
 
+currently unsupported:
+ - 16 bit char output
+  - [qmk](https://github.com/jackhumbert/qmk_firmware)
+    supports 16 bit chars, but currently has no support for i2c ErgoDox.
+
 ## Building
 
 ### Dependencies


### PR DESCRIPTION
Not sure how else to put the, I think, 8bit limitation in the readme.
